### PR TITLE
Cleaning appointments data

### DIFF
--- a/analysis/calculate_lead_times.py
+++ b/analysis/calculate_lead_times.py
@@ -3,21 +3,21 @@ import sys
 
 sys.path.append("lib")
 
-from utilities import OUTPUT_DIR, match_long_input_files
+from utilities import OUTPUT_DIR, match_input_files_by_tag
 
 
 def calculate_lead_times():
     for file in OUTPUT_DIR.iterdir():
 
         ### Identify wide format input files
-        if match_long_input_files(file.name):
+        if match_input_files_by_tag(file.name,"clean"):
             ### Read contents of file
             df = pd.read_csv(OUTPUT_DIR / file.name)
             ### Convert string dates actual dates and calculate lead time
             df[['booked_date_appointment','start_date_appointment']] = df[['booked_date_appointment','start_date_appointment']].apply(pd.to_datetime)
             df['lead_time'] = (df['booked_date_appointment'] - df['start_date_appointment']).dt.days
             ### Write contents to file
-            new_file_name = file.name.replace("long", "processed")
+            new_file_name = file.name.replace("clean", "processed")
             df.to_csv(OUTPUT_DIR / new_file_name, index=False)
 
 if __name__ == "__main__":

--- a/analysis/clean_data.py
+++ b/analysis/clean_data.py
@@ -1,0 +1,24 @@
+import pandas as pd
+import sys
+
+sys.path.append("lib")
+
+from utilities import OUTPUT_DIR, match_input_files_by_tag
+
+
+def clean_data():
+
+    for file in OUTPUT_DIR.iterdir():
+
+        # Identify wide format input files
+        if match_input_files_by_tag(file.name,"long"):
+            # Read contents of file
+            df = pd.read_csv(OUTPUT_DIR / file.name)
+            df['booked_date_appointment'] = pd.to_datetime(df['booked_date_appointment'])
+            df['start_date_appointment'] = pd.to_datetime(df['start_date_appointment'])
+            df_clean = df.loc[df['booked_date_appointment'] > df['start_date_appointment']]
+            new_file_name = file.name.replace("long", "clean")
+            df_clean.to_csv(OUTPUT_DIR / new_file_name, index=False)
+
+if __name__ == "__main__":
+    clean_data()

--- a/project.yaml
+++ b/project.yaml
@@ -16,14 +16,21 @@ actions:
     needs: [generate_study_population]
     outputs:
       highly_sensitive:
-        reformatted: output/input_long*.csv
+        reformatted: output/input_long_*.csv
 
-  calculate_lead_times:
-    run: python:latest python analysis/calculate_lead_times.py
+  perform_quality_assurance:
+    run: python:latest python analysis/clean_data.py
     needs: [reformat_appointment_data]
     outputs:
       highly_sensitive:
-        calculated: output/input_processed*.csv
+        reformatted: output/input_clean_*.csv
+
+  calculate_lead_times:
+    run: python:latest python analysis/calculate_lead_times.py
+    needs: [perform_quality_assurance]
+    outputs:
+      highly_sensitive:
+        calculated: output/input_processed_*.csv
 
   summarise_lead_times:
     run: python:latest python analysis/summarise_lead_times.py


### PR DESCRIPTION
This RE implements a quality assurance step which:

- removes appointments where the booking is recorded as having taken place after the start date
- makes the necessary changes to `project.yaml` and `calculate_lead_times.py`

We do not record the number of appointments *as yet* but this remains in the #5 issue to be added later.

**Currently a draft PR as I would like to rebase following a merge of #11).**