### PR TITLE
Replace placeholder tables

### DIFF
--- a/analysis/dataset_definition.py
+++ b/analysis/dataset_definition.py
@@ -1,8 +1,7 @@
 import datetime
 
 from databuilder import ehrql
-from databuilder.tables.beta.tpp import practice_registrations
-from placeholder_tables import appointments
+from databuilder.tables.beta.tpp import appointments, practice_registrations
 
 index_date = datetime.date(2020, 1, 1)
 

--- a/analysis/placeholder_tables.py
+++ b/analysis/placeholder_tables.py
@@ -1,9 +1,0 @@
-import datetime
-
-from databuilder.tables import EventFrame, Series, table
-
-
-@table
-class appointments(EventFrame):
-    booked_date = Series(datetime.date)  # book_date ?
-    start_date = Series(datetime.date)


### PR DESCRIPTION
Now that opensafely-core/databuilder#923 has been merged, we can replace placeholder tables with Data Builder tables.

---

⚠️ If you wish to test this branch locally, then you should first update the Data Builder image. At present, `opensafely pull` won't update it (opensafely-core/opensafely-cli#158). So, you will need to `docker pull ghcr.io/opensafely-core/databuilder:v0` instead.