### PR TITLE
Change output format from csv to arrow

### DIFF
--- a/analysis/generate_measure.py
+++ b/analysis/generate_measure.py
@@ -1,14 +1,23 @@
 import pandas
+from pandas.api.types import is_datetime64_any_dtype
 from pandas.tseries.offsets import MonthBegin
 
 from analysis.utils import OUTPUT_DIR
 
-f_in = OUTPUT_DIR / "dataset_long.csv"
+f_in = OUTPUT_DIR / "dataset_long.arrow"
 f_out = OUTPUT_DIR / "measure_median_lead_time_in_days_by_nunique_patient_id.csv"
 
 
 def main():
-    dataset_long = pandas.read_csv(f_in, parse_dates=["booked_date"])
+    dataset_long = pandas.read_feather(f_in)
+
+    # Although booked_date is derived from column of type date, it is represented as a
+    # string by the dummy data generator. That may be a bug in the dummy data generator,
+    # so we log and, if necessary, cast.
+    print(f"booked_date is of type {dataset_long.booked_date.dtypes}")
+    if not is_datetime64_any_dtype(dataset_long["booked_date"]):
+        dataset_long["booked_date"] = pandas.to_datetime(dataset_long["booked_date"])
+
     dataset_long["booked_date"] = dataset_long["booked_date"] - MonthBegin(1)
 
     by_practice = dataset_long.groupby(["booked_date", "practice"]).aggregate(

--- a/analysis/get_freq_na_values.py
+++ b/analysis/get_freq_na_values.py
@@ -7,7 +7,9 @@ def read_cols(f_path, prefix):
     """
     Reads columns with the given prefix from the data frame at the given file path.
     """
-    return pandas.read_csv(f_path, usecols=lambda x: x.startswith(prefix))
+    dataframe = pandas.read_feather(f_path)
+    dataframe = dataframe.loc[:, (x for x in dataframe.columns if x.startswith(prefix))]
+    return dataframe
 
 
 def get_freq_na_values(dataframe, normalize=False):
@@ -29,7 +31,7 @@ def write(dataframe, f_path):
 
 
 def main():
-    booked_dates = read_cols(OUTPUT_DIR / "dataset_wide.csv", "booked_date_")
+    booked_dates = read_cols(OUTPUT_DIR / "dataset_wide.arrow", "booked_date_")
     freq_na_values = get_freq_na_values(booked_dates)
     write(freq_na_values, OUTPUT_DIR / "freq_na_values.csv")
 

--- a/analysis/reshape_dataset.py
+++ b/analysis/reshape_dataset.py
@@ -2,12 +2,12 @@ import pandas
 
 from analysis.utils import OUTPUT_DIR
 
-f_in = OUTPUT_DIR / "dataset_wide.csv"
-f_out = OUTPUT_DIR / "dataset_long.csv"
+f_in = OUTPUT_DIR / "dataset_wide.arrow"
+f_out = OUTPUT_DIR / "dataset_long.arrow"
 
 
 def main():
-    dataset_wide = pandas.read_csv(f_in)
+    dataset_wide = pandas.read_feather(f_in)
     dataset_long = pandas.wide_to_long(
         dataset_wide,
         ["booked_date", "lead_time_in_days"],
@@ -15,7 +15,9 @@ def main():
         "appointment_num",
         sep="_",
     )
-    dataset_long.to_csv(f_out)
+    # dataset_long has a MultiIndex; feather only supports a RangeIndex. So, we reset
+    # before we write.
+    dataset_long.reset_index().to_feather(f_out)
 
 
 if __name__ == "__main__":

--- a/project.yaml
+++ b/project.yaml
@@ -10,10 +10,10 @@ actions:
       databuilder:v0
         generate-dataset
         analysis/dataset_definition.py
-        --output output/dataset_wide.csv
+        --output output/dataset_wide.arrow
     outputs:
       highly_sensitive:
-        dataset: output/dataset_wide.csv
+        dataset: output/dataset_wide.arrow
 
   get_freq_na_values:
     run: >
@@ -33,7 +33,7 @@ actions:
     needs: [generate_dataset]
     outputs:
       highly_sensitive:
-        dataset: output/dataset_long.csv
+        dataset: output/dataset_long.arrow
 
   generate_measure:
     run: >


### PR DESCRIPTION
We should change from csv to arrow sooner rather than later—and whilst we're developing the study—because the dataset definition is likely to generate very large, wide datasets (`generate_dataset`), which are reshaped into very large, long datasets (`reshape_dataset`). Not only should we ensure these datasets are as small as possible because of a limited amount of storage on L3, but also because they are repeatedly copied from L3 to containers, which takes time.[^1]

That said, we don't need to change _every_ csv file to an arrow file: some files are small and need to be 👀 on L4 (`get_freq_na_values`); some files can only be csv files, because downstream reusable actions don't read feather files (`generate_measure`).

If you're developing the study and would like to 👀 the dummy data, then you could run `opensafely jupyter` from within the repo, create a new notebook, and open the dummy data with `pandas.read_feather("...")`. Alternatively, you could run

```sh
docker run --rm --interactive --tty --volume $(pwd):/workspace --workdir /workspace --entrypoint ipython ghcr.io/opensafely-core/python
```

which creates a new, temporary [ipython][1] shell within which you could do the same. My preference is the shell; yours may be the notebook 🙂.

Closes #8

[^1]: We should have an idea of how much time when [the first job request](https://jobs.opensafely.org/datalab/gp-appointments-during-covid/winter-pressures/logs/) has completed.

[1]: https://ipython.readthedocs.io/en/stable/