### PR TITLE
Fix negated lead times

### DIFF
--- a/analysis/appointments/dataset_query.sql
+++ b/analysis/appointments/dataset_query.sql
@@ -68,8 +68,8 @@ SELECT
     DATEFROMPARTS(YEAR(booked_date), MONTH(booked_date), 1) AS booked_month,
     DATEDIFF(
         DAY,
-        start_date,
-        booked_date
+        booked_date,
+        start_date
     ) AS lead_time_in_days
 FROM valid_appointments
 WHERE


### PR DESCRIPTION
Lead times were negated because the arguments to `DATEDIFF` were the wrong way around: the earlier date should be first (position 2) and the later date should be second (position 3) [1]. The function shouldn't be read as a subtraction of a larger, later date from a smaller, earlier date.

[1]: https://learn.microsoft.com/en-us/sql/t-sql/functions/datediff-transact-sql