### PR TITLE
Revert "Take absolute value of lead times"

### DIFF
--- a/analysis/appointments/generate_measure.py
+++ b/analysis/appointments/generate_measure.py
@@ -49,11 +49,6 @@ def read(f_in):
 
 def main():
     dataset_long = read(f_in)
-
-    # FIXME: Until we rerun the `appointments_generate_dataset_sql` action, lead times
-    # will be negated (7a44dfa). They shouldn't be, so we take their absolute value.
-    dataset_long["lead_time_in_days"] = dataset_long["lead_time_in_days"].abs()
-
     by_practice = dataset_long.groupby(["booked_month", "practice"]).median()
     del dataset_long
 


### PR DESCRIPTION
This reverts commit 0aa104374ea24bc04aede740e7d004ba036c5072.

We should do this now, before we forget, and immediately `run_all`. If we didn't, and if we decided to investigate negative lead times, then we'd not find any 😕