### PR TITLE
Removing practice ID from measures output

### DIFF
--- a/analysis/appointments/generate_median_lead_time_measure.py
+++ b/analysis/appointments/generate_median_lead_time_measure.py
@@ -26,6 +26,7 @@ def main():
     del medians
     measure.columns = ["date", "practice", "value"]  # rename columns
     measure = measure.loc[:, ["value", "date"]]  # reorder columns
+
     f_out = OUTPUT_DIR / f"measure_median_{args.value_col}_by_{date_col}.csv"
     measure.to_csv(f_out, index=False)
 

--- a/analysis/appointments/generate_num_appointments_measure.py
+++ b/analysis/appointments/generate_num_appointments_measure.py
@@ -25,6 +25,7 @@ def main():
     del counts
     measure.columns = ["date", "practice", "value"]  # rename columns
     measure = measure.loc[:, ["value", "date"]]  # reorder columns
+
     f_out = OUTPUT_DIR / f"measure_num_appointments_by_{date_col}.csv"
     measure.to_csv(f_out, index=False)
 

--- a/analysis/appointments/generate_num_unique_patients_measure.py
+++ b/analysis/appointments/generate_num_unique_patients_measure.py
@@ -26,6 +26,7 @@ def main():
     del num_patients
     measure.columns = ["date", "practice", "value"]  # rename columns
     measure = measure.loc[:, ["value", "date"]]  # reorder columns
+
     f_out = OUTPUT_DIR / f"measure_num_unique_patients_by_{date_col}.csv"
     measure.to_csv(f_out, index=False)
 

--- a/analysis/appointments/generate_proportion_lead_time_measure.py
+++ b/analysis/appointments/generate_proportion_lead_time_measure.py
@@ -34,7 +34,6 @@ def main():
 
     measure = total_counts.reset_index().rename(columns={date_col: "date"})
     del total_counts
-
     measure = measure.loc[:, ["value", "date"]]  # reorder columns
 
     f_out = (


### PR DESCRIPTION
Looking at the output on the server, the values for the proportion within 0/2 days are not bounded by 0 and 1. I'm wondering whether this is because practice ID is being read as either the numerator or denominator. @iaindilligham did mention this previously and I did run a version of the pipeline with and without practice ID locally, which didn't seem to make a difference to the decile plots that were generated. I have also tried to run a version locally that has more realistic practice IDs (i.e., not 1/2/3 but 1000, 2000, 3000) but this didn't seem to make any difference either.

In any case, this commit removes practice from the measures file, to see if the output is more sensible.