### PR TITLE
Fixing one of the kids presentation measures

### DIFF
--- a/analysis/study_definition_kids.py
+++ b/analysis/study_definition_kids.py
@@ -122,7 +122,7 @@ measures = [
 ),
 
     Measure(
-    id=f"over12_appt_pop_rate",
+    id=f"under12_appt_pop_rate",
     numerator="appt_under12",
     denominator="population",
     group_by=["practice"]


### PR DESCRIPTION
There was a typo in `study_definition_kids.py` where two `over12_appt_pop_rate` measures were being created, when one should have read `under12_appt_pop_rate`. This is fixed in this PR.