### PR TITLE
Generating decile plots for SRO and kids presentation measures

### DIFF
--- a/analysis/study_definition_kids_monthly.py
+++ b/analysis/study_definition_kids_monthly.py
@@ -1,0 +1,127 @@
+# Import functions
+
+from cohortextractor import (
+    StudyDefinition,
+    patients,
+    codelist_from_csv,
+    codelist,
+    Measure,
+    params
+)
+
+# Import codelists
+
+from codelists import *
+from datetime import date
+
+start_date = "2018-06-01"
+
+# Specifiy study definition
+study = StudyDefinition(
+    index_date=start_date,
+    default_expectations={
+        "date": {"earliest": "index_date", "latest": "today"},
+        "rate": "exponential_increase",
+        "incidence": 0.1,
+    },
+    population = patients.satisfying(
+        """
+        registered AND
+        (NOT died) 
+        """,
+    ),
+    
+    registered = patients.registered_as_of(
+        "index_date",
+        return_expectations={"incidence": 0.9},
+        ),
+    
+    died = patients.died_from_any_cause(
+        on_or_before="index_date",
+        returning="binary_flag",
+        return_expectations={"incidence": 0.1}
+        ),
+
+    age=patients.age_as_of(
+        "index_date",
+        return_expectations={
+            "rate": "universal",
+            "int": {"distribution": "population_ages"},
+        },
+    ),
+
+    practice=patients.registered_practice_as_of(
+        "index_date",
+        returning="pseudo_id",
+        return_expectations={"int" : {"distribution": "normal", "mean": 25, "stddev": 5}, "incidence" : 0.5}
+    ),
+
+
+    population_over12 = patients.satisfying(
+        """
+        (age >11 AND age <=15) 
+        """,
+    ),
+
+    population_under12 = patients.satisfying(
+        """
+        (age >=5 AND age <=11) 
+        """,
+    ),
+
+    ### appointment 
+    appt = patients.with_gp_consultations(
+        between=["first_day_of_month(index_date)", "last_day_of_month(index_date)"],
+        returning="binary_flag",
+        return_expectations={"incidence": 0.5}
+    ), 
+
+    appt_over12 = patients.satisfying(
+    """
+    appt AND
+    population_over12
+    """
+    ),
+
+    appt_under12 = patients.satisfying(
+    """
+    appt AND
+    population_under12
+    """
+    )
+
+)
+#### Measures
+
+measures = [
+    ##### child appt rate per child population
+    Measure(
+    id=f"over12_appt_rate",
+    numerator="appt_over12",
+    denominator="population_over12",
+    group_by=["practice"]
+),
+
+    Measure(
+    id=f"under12_appt_rate",
+    numerator="appt_under12",
+    denominator="population_under12",
+    group_by=["practice"]
+),
+    
+    ##### child rate per total population
+    Measure(
+    id=f"over12_appt_pop_rate",
+    numerator="appt_over12",
+    denominator="population",
+    group_by=["practice"]
+),
+
+    Measure(
+    id=f"under12_appt_pop_rate",
+    numerator="appt_under12",
+    denominator="population",
+    group_by=["practice"]
+),
+
+]

--- a/analysis/study_definition_sro_monthly.py
+++ b/analysis/study_definition_sro_monthly.py
@@ -1,0 +1,252 @@
+# Import functions
+
+from cohortextractor import (
+    StudyDefinition,
+    patients,
+    codelist_from_csv,
+    codelist,
+    Measure,
+    params
+)
+sentinel_measures = ["qrisk2", "asthma", "copd", "sodium", "cholesterol", "alt", "tsh", "rbc", 'hba1c', 'systolic_bp', 'medication_review']
+
+# Import codelists
+
+from codelists import *
+from datetime import date
+
+start_date = "2018-06-01"
+
+# Specifiy study definition
+study = StudyDefinition(
+    index_date=start_date,
+
+    default_expectations={
+        "date": {"earliest": "index_date", "latest": "today"},
+        "rate": "exponential_increase",
+        "incidence": 0.1,
+    },
+    population=patients.satisfying(
+        """
+        registered AND
+        (NOT died) AND
+        (age >=18 AND age <=120) 
+        """,
+    ),
+
+    registered=patients.registered_as_of(
+            "index_date",
+            return_expectations={"incidence": 0.9},
+        ),
+
+    age=patients.age_as_of(
+            "index_date",
+            return_expectations={
+                "rate": "universal",
+                "int": {"distribution": "population_ages"},
+            },
+        ),
+        
+        died = patients.died_from_any_cause(
+        on_or_before="index_date",
+        returning="binary_flag",
+        return_expectations={"incidence": 0.1}
+        ),
+
+    practice=patients.registered_practice_as_of(
+        "index_date",
+        returning="pseudo_id",
+        return_expectations={"int" : {"distribution": "normal", "mean": 25, "stddev": 5}, "incidence" : 0.5}
+    ),
+
+    ##### SRO measures
+
+    medication_review =patients.with_these_clinical_events(
+        codelist=medication_review_codelist,
+        between=["first_day_of_month(index_date)", "last_day_of_month(index_date)"],
+        returning="binary_flag",
+        return_expectations={"incidence": 0.5}
+    ),
+
+    medication_review_event_code=patients.with_these_clinical_events(
+        codelist=medication_review_codelist,
+        between=["first_day_of_month(index_date)", "last_day_of_month(index_date)"],
+        returning="code",
+        return_expectations={"category": {
+            "ratios": {str(1079381000000109): 0.6, str(1127441000000107): 0.2, str(1239511000000100): 0.2}}, }
+    ),
+    
+    systolic_bp =patients.with_these_clinical_events(
+        codelist=systolic_bp_codelist,
+        between=["first_day_of_month(index_date)", "last_day_of_month(index_date)"],
+        returning="binary_flag",
+        return_expectations={"incidence": 0.5}
+    ),
+
+    systolic_bp_event_code=patients.with_these_clinical_events(
+        codelist=systolic_bp_codelist,
+        between=["first_day_of_month(index_date)", "last_day_of_month(index_date)"],
+        returning="code",
+        return_expectations={"category": {
+            "ratios": {str(198081000000101): 0.6, str(251070002): 0.2, str(271649006): 0.2}}, }
+    ),
+    
+  
+    qrisk2 =patients.with_these_clinical_events(
+        codelist=qrisk_codelist,
+        between=["first_day_of_month(index_date)", "last_day_of_month(index_date)"],
+        returning="binary_flag",
+        return_expectations={"incidence": 0.5}
+    ),
+
+    qrisk2_event_code=patients.with_these_clinical_events(
+        codelist=qrisk_codelist,
+        between=["first_day_of_month(index_date)", "last_day_of_month(index_date)"],
+        returning="code",
+        return_expectations={"category": {
+            "ratios": {str(1085871000000105): 0.6, str(450759008): 0.2, str(718087004): 0.2}}, }
+    ),
+
+    cholesterol =patients.with_these_clinical_events(
+        codelist=cholesterol_codelist,
+        between=["first_day_of_month(index_date)", "last_day_of_month(index_date)"],
+        returning="binary_flag",
+        return_expectations={"incidence": 0.5}
+    ),
+
+    cholesterol_event_code=patients.with_these_clinical_events(
+        codelist=cholesterol_codelist,
+        between=["first_day_of_month(index_date)", "last_day_of_month(index_date)"],
+        returning="code",
+        return_expectations={"category": {
+            "ratios": {str(1005671000000105): 0.8, str(1017161000000104): 0.2}}, }
+    ),
+    
+    alt =patients.with_these_clinical_events(
+        codelist=alt_codelist,
+        between=["first_day_of_month(index_date)", "last_day_of_month(index_date)"],
+        returning="binary_flag",
+        return_expectations={"incidence": 0.5}
+    ),
+
+    alt_event_code=patients.with_these_clinical_events(
+        codelist=alt_codelist,
+        between=["first_day_of_month(index_date)", "last_day_of_month(index_date)"],
+        returning="code",
+        return_expectations={"category": {
+            "ratios": {str(1013211000000103): 0.8, str(1018251000000107): 0.2}}, }
+    ),
+
+    tsh =patients.with_these_clinical_events(
+        codelist=tsh_codelist,
+        between=["first_day_of_month(index_date)", "last_day_of_month(index_date)"],
+        returning="binary_flag",
+        return_expectations={"incidence": 0.5}
+    ),
+
+    tsh_event_code=patients.with_these_clinical_events(
+        codelist=tsh_codelist,
+        between=["first_day_of_month(index_date)", "last_day_of_month(index_date)"],
+        returning="code",
+        return_expectations={"category": {
+            "ratios": {str(1022791000000101): 0.8, str(1022801000000102): 0.2}}, }
+    ),
+
+    rbc =patients.with_these_clinical_events(
+        codelist=rbc_codelist,
+        between=["first_day_of_month(index_date)", "last_day_of_month(index_date)"],
+        returning="binary_flag",
+        return_expectations={"incidence": 0.5}
+    ),
+
+    rbc_event_code=patients.with_these_clinical_events(
+        codelist=rbc_codelist,
+        between=["first_day_of_month(index_date)", "last_day_of_month(index_date)"],
+        returning="code",
+        return_expectations={"category": {
+            "ratios": {str(1022451000000103): 1}}, }
+    ),
+
+    hba1c =patients.with_these_clinical_events(
+        codelist=hba1c_codelist,
+        between=["first_day_of_month(index_date)", "last_day_of_month(index_date)"],
+        returning="binary_flag",
+        return_expectations={"incidence": 0.5}
+    ),
+
+    hba1c_event_code=patients.with_these_clinical_events(
+        codelist=hba1c_codelist,
+        between=["first_day_of_month(index_date)", "last_day_of_month(index_date)"],
+        returning="code",
+        return_expectations={"category": {
+            "ratios": {str(1003671000000109): 0.6, str(144176003): 0.2, str(166902009): 0.2}}, }
+    ),
+
+    sodium =patients.with_these_clinical_events(
+        codelist=sodium_codelist,
+        between=["first_day_of_month(index_date)", "last_day_of_month(index_date)"],
+        returning="binary_flag",
+        return_expectations={"incidence": 0.5}
+    ),
+
+    sodium_event_code=patients.with_these_clinical_events(
+        codelist=sodium_codelist,
+        between=["first_day_of_month(index_date)", "last_day_of_month(index_date)"],
+        returning="code",
+        return_expectations={"category": {
+            "ratios": {str(1000661000000107): 0.6, str(1017381000000106): 0.4}}, }
+    ),
+
+    asthma =patients.with_these_clinical_events(
+        codelist=asthma_codelist,
+        between=["first_day_of_month(index_date)", "last_day_of_month(index_date)"],
+        returning="binary_flag",
+        return_expectations={"incidence": 0.5}
+    ),
+
+    asthma_event_code=patients.with_these_clinical_events(
+        codelist=asthma_codelist,
+        between=["first_day_of_month(index_date)", "last_day_of_month(index_date)"],
+        returning="code",
+        return_expectations={"category": {
+            "ratios": {str(270442000): 0.6, str(390872009): 0.2, str(390877003): 0.2}}, }
+    ),
+
+    copd =patients.with_these_clinical_events(
+        codelist=copd_codelist,
+        between=["first_day_of_month(index_date)", "last_day_of_month(index_date)"],
+        returning="binary_flag",
+        return_expectations={"incidence": 0.5}
+    ),
+
+    copd_event_code=patients.with_these_clinical_events(
+        codelist=copd_codelist,
+        between=["first_day_of_month(index_date)", "last_day_of_month(index_date)"],
+        returning="code",
+        return_expectations={"category": {
+            "ratios": {str(394703002): 0.6, str(760601000000107): 0.2, str(760621000000103): 0.2}}, }
+    ),
+)
+#### Measures
+
+measures = [ ]
+
+
+### SRO measures
+for measure in sentinel_measures:
+    measure
+    measures.extend([
+        Measure(
+        id=f"{measure}_rate",
+        numerator=measure,
+        denominator="population",
+        group_by=["practice", f"{measure}_event_code"]
+    ),
+
+        Measure(
+        id=f"{measure}_practice_only_rate",
+        numerator=measure,
+        denominator="population",
+        group_by=["practice"]
+    )
+    ])

--- a/project.yaml
+++ b/project.yaml
@@ -14,6 +14,55 @@ actions:
   # "metrics_"; we would place our scripts in analysis/metrics; we would write outputs
   # to output/metrics.
 
+  metrics_monthly_sro_data:
+    run: cohortextractor:latest generate_cohort --study-definition study_definition_sro_monthly
+        --index-date-range '2018-06-01 to 2022-12-31 by month' --output-dir=output/metrics/monthly
+        --output-format=feather
+    outputs:
+      highly_sensitive:
+        extract: output/metrics/monthly/input_sro_monthly*.feather
+
+  metrics_monthly_sro_data_measures:
+    run: cohortextractor:latest generate_measures --study-definition study_definition_sro_monthly --output-dir=output/metrics/monthly
+    needs:
+    - metrics_monthly_sro_data
+    outputs:
+      moderately_sensitive:
+        measure_csv: output/metrics/monthly/measure_*.csv
+
+  metrics_monthly_kids_data:
+    run: cohortextractor:latest generate_cohort --study-definition study_definition_kids_monthly
+        --index-date-range '2018-06-01 to 2022-12-31 by month' --output-dir=output/metrics/monthly
+        --output-format=feather
+    outputs:
+      highly_sensitive:
+        extract: output/metrics/monthly/input_kids_monthly*.feather
+
+  metrics_monthly_kids_data_measures:
+    run: cohortextractor:latest generate_measures --study-definition study_definition_kids_monthly --output-dir=output/metrics/monthly
+    needs:
+    - metrics_monthly_kids_data
+    outputs:
+      moderately_sensitive:
+        measure_csv: output/metrics/monthly/measure*.csv
+
+  metrics_generate_deciles_charts:
+    run: >
+      deciles-charts:v0.0.33
+        --input-files output/metrics/monthly/measure_*.csv
+        --output-dir output/metrics
+    config:
+      show_outer_percentiles: true
+    needs:
+      - metrics_monthly_sro_data_measures
+      - metrics_monthly_kids_data_measures
+    outputs:
+      moderately_sensitive:
+        deciles_charts: output/metrics/deciles_chart_*.png
+        deciles_tables: output/metrics/deciles_table_*.csv
+
+
+
   # Metrics data extraction
   # ------------
   metrics_generate_sro_dataset_winter:


### PR DESCRIPTION
This PR adds the necessary functionality to:
- extract monthly data for the SRO and the kids presentation measures
- generate decile plots for these measures

The study period matches that used by the appointment data deciles plots: 1st June 2018 to 31st December 2022. This is hardcoded into the `project.yaml`.