### PR TITLE
Restoring missing decile plots

### DIFF
--- a/project.yaml
+++ b/project.yaml
@@ -371,6 +371,7 @@ actions:
     run: r:latest -e 'rmarkdown::render("reports/preliminary_report.rmd", output_dir = "/workspace/output/docs", knit_root_dir = "/workspace",)'
     needs: 
       - metrics_create_seasonal_measures
+      - metrics_generate_deciles_charts
       - appointments_generate_deciles_charts
       - appointments_generate_seasonal_summaries_by_booked_month
       - appointments_generate_seasonal_summaries_by_start_month


### PR DESCRIPTION
We were missing `metrics_generate_deciles_charts` from the `needs:` of `generate_preliminary_report`. This has been added now.