### PR TITLE
Fix copy of seasonal histograms to release folder

### DIFF
--- a/analysis/create_release.R
+++ b/analysis/create_release.R
@@ -92,10 +92,11 @@ seasonal_comparison_histograms <- list.files(
 for (f in seasonal_comparison_histograms ) {
     f_dir = dirname(f)
     f_file = basename(f)
+    measure_string = basename(f_dir)
 
     fs::file_copy(
         f,
-        fs::path(seasonal_comparison_output_dir, f_file),
+        fs::path(seasonal_comparison_output_dir, glue("{measure_string}_{f_file}")),
         overwrite = TRUE
     )
 }


### PR DESCRIPTION
Because the source files were all called the same thing, they were overwriting each other when being copied to the release folder. This change prepends the measure name to the file name so that this doesn't happen and ALL files are included in the release.