### PR TITLE
remove restriction  to adult population

### DIFF
--- a/analysis/study_definition_epi.py
+++ b/analysis/study_definition_epi.py
@@ -36,8 +36,7 @@ study = StudyDefinition(
     population=patients.satisfying(
         """
         registered AND
-        (NOT died) AND
-        (age >=18 AND age <=120) 
+        (NOT died)
         """,
     ),
     start_date = patients.fixed_value(start_date),


### PR DESCRIPTION
The Epi outcomes population was restricted to `(age >=18 AND age <=120)`. This PR removes the age restriction